### PR TITLE
turn back on linter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 - chmod +x ./.build_scripts/deploy.sh
 - chmod +x ./.build_scripts/lint.sh
 before_script:
-# - "./.build_scripts/lint.sh"
+- "./.build_scripts/lint.sh"
 - npm test
 script:
 - npm run build


### PR DESCRIPTION
the disabled lint tests should not remain in place, but the errors need to be resolved, preferably by upgrading to a more current version of node